### PR TITLE
Bug in User-Abfrage behoben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **20.01.2023 Version 1.0.2**
+
+- Bugfix: BlueScreen nach Logout behoben (#5)
+
 ## **20.01.2023 Version 1.0.1**
 
 - Bugfix: in SQL-PreparedStatements die Platzhalter durch ihre Werte ersetzen (#4). Unterstützer: Thomas Blum (@tbaddade)

--- a/boot.php
+++ b/boot.php
@@ -27,6 +27,9 @@ use rex_perm;
 
 rex_perm::register('yform_adminer[]');
 
-if (rex::isBackend() && rex::requireUser()->hasPerm('yform_adminer[]') && rex_addon::get('yform')->isAvailable() && rex_addon::get('adminer')->isAvailable()) {
-    YFormAdminer::init();
+if( rex::isBackend()) {
+    $user = rex::getUser();
+    if (null !== $user && $user->hasPerm('yform_adminer[]') && rex_addon::get('yform')->isAvailable() && rex_addon::get('adminer')->isAvailable()) {
+        YFormAdminer::init();
+    }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform_adminer
-version: '1.0.1'
+version: '1.0.2'
 author: 'FriendsOfRedaxo | Christoph Böcker'
 supportpage: https://github.com/FriendsOfREDAXO/yform_adminer
 


### PR DESCRIPTION
Beim Logout lief das System in einen Absturz. Ursache war das nach dem Logout fehlende User-Objekt. Lösung: von RequireUser wieder auf GetUser umgestellt.