### PR TITLE
einige Methoden freigegeben (public)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## **09.03.2023 1.2.0**
+## **11.03.2023 1.4.0**
+
+- interne Funktonen für Direkt-Aufrufe in YForm freigegeben ('public' statt 'protected')
+  - `YFormAdminer::dbTable(string $tablename, array $where = [])`  
+    zeigt die angegebene Tabelle im Adminer. Über den Parameter `where` kann
+    die Tabelle gefiltert werden `[['col'=>'spalte','op'=>'operator','val'=>'vergleichswert'],...]`
+  - `YFormAdminer::dbSql(string $query)`  
+    ruft die Adminer-Seite "SQL-Kommando" mit dem angegebenen SQL-Query-String auf.
+    Das Kommendo wird nicht ausgeführt, nur angezeigt
+  - `YFormAdminer::dbEdit($table_name,$data_id)`
+    Ruft die edit-Maske für den angegebenen Datensatz der Tabelle im Adminer auf.
+
+## **09.03.2023 1.3.0**
 
 - Callback umgestellt auf die "First Class Callable Syntax" bzw. "Callback-Funktionen als Objekte erster Klasse", also statt `[self::class, 'methode']` nun `self::methode(...)`. Damit wird die statische Code-Analyse verbessert (IDE, RexStan). (@christophboecker #18)
 - Notwendige Anhebung der Vorrausetzungen auf PHP ^8.1 und REDAXO ^5.15.

--- a/lib/YFormAdminer.php
+++ b/lib/YFormAdminer.php
@@ -300,22 +300,36 @@ class YFormAdminer
 
     /**
      * Adminer: zeigt die angegebene Tabelle im Adminer.
+     * Where ist optional, muss aber diesen Aufbau haben, der nicht
+     * weiter überprüft wird!
+     *  [
+     *      [
+     *          'col' => spaltenname,
+     *          'op' => operator
+     *          'val' => vergleichswert
+     *      ],
+     *      ...
+     *  ].
      * @ api
      */
-    protected static function dbTable(string $tablename): string
+    public static function dbTable(string $tablename, array $where = []): string
     {
-        return self::baseUrl(
-            [
-                'select' => $tablename,
-            ],
-        );
+        $params = [
+            'select' => $tablename,
+        ];
+        foreach ($where as $key => $item) {
+            foreach ($item as $k => $v) {
+                $params[sprintf('where[%s][%s]',$key, $k)] = $v;
+            }
+        }
+        return self::baseUrl($params);
     }
 
     /**
      * Adminer: ruft die Adminer-Seite "SQL-Kommando" auf.
      * @ api
      */
-    protected static function dbSql(string $query): string
+    public static function dbSql(string $query): string
     {
         return self::baseUrl(
             [
@@ -337,7 +351,7 @@ class YFormAdminer
      * Adminer: Ruft die edit-Maske für den angegebenen Datensatz der Tabelle im Adminer auf.
      * @ api
      */
-    protected static function dbEdit(string $tablename, int|string $id): string
+    public static function dbEdit(string $tablename, int|string $id): string
     {
         return self::baseUrl(
             [
@@ -353,12 +367,14 @@ class YFormAdminer
      */
     protected static function YformTableTable(string $tablename): string
     {
-        return self::baseUrl(
+        return self::dbTable(
+            rex::getTable('yform_table'),
             [
-                'select' => rex::getTable('yform_table'),
-                'where[0][col]' => 'table_name',
-                'where[0][op]' => '=',
-                'where[0][val]' => $tablename,
+                [
+                    'col' => 'table_name',
+                    'op' => '=',
+                    'val' => $tablename,
+                ],
             ],
         );
     }
@@ -369,12 +385,14 @@ class YFormAdminer
      */
     protected static function yformFieldTable(string $tablename): string
     {
-        return self::baseUrl(
+        return self::dbTable(
+            rex::getTable('yform_field'),
             [
-                'select' => rex::getTable('yform_field'),
-                'where[0][col]' => 'table_name',
-                'where[0][op]' => '=',
-                'where[0][val]' => $tablename,
+                [
+                    'col' => 'table_name',
+                    'op' => '=',
+                    'val' => $tablename,
+                ],
             ],
         );
     }
@@ -385,12 +403,14 @@ class YFormAdminer
      */
     protected static function yformFieldItem(int|string $id): string
     {
-        return self::baseUrl(
+        return self::dbTable(
+            rex::getTable('yform_field'),
             [
-                'select' => rex::getTable('yform_field'),
-                'where[0][col]' => 'id',
-                'where[0][op]' => '=',
-                'where[0][val]' => $id,
+                [
+                    'col' => 'id',
+                    'op' => '=',
+                    'val' => $id,
+                ],
             ],
         );
     }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform_adminer
-version: '1.3.0'
+version: '1.4.0'
 author: 'FriendsOfRedaxo | Christoph Böcker'
 supportpage: https://github.com/FriendsOfREDAXO/yform_adminer
 


### PR DESCRIPTION
Die Methoden 
- `YFormAdminer::dbTable(string $tablename, array $where = [])`
- `YFormAdminer::dbSql(string $query)`
- `YFormAdminer::dbEdit($table_name,$data_id)`

zum Erzeugen vor Urls, die direkt SubSeiten im Adminer ansteuern, sind nun `public` statt `protected`.
