### PR TITLE
Package.ym und readme angepasst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **23-08-2024 1.4.1**
+
+- Fehler in _packege.yml_ behoben: `requires` für Redaxo-Packages korrigiert.
+
 ## **11.03.2023 1.4.0**
 
 - interne Funktonen für Direkt-Aufrufe in YForm freigegeben ('public' statt 'protected')

--- a/README.md
+++ b/README.md
@@ -62,6 +62,48 @@ Hier das CSS der obigen Bildbeispiele:
 }
 ```
 
+## Nutzung in eigenen Addons
+
+Einige Methoden zum Aufbau einer Adminer-URL stehen zur Nutzung in eigenen Addons zur Verfügung.
+Bitte dabei beachten, dass YForm_Adminer wie Adminer nur für Admins und nicht im LiveMode verfügbar ist.
+
+```php
+// Tabelle anzeigen
+$url1 = YFormAdminer::dbTable(
+    rex::getTable('config'),
+);
+
+// Gefilterte Tabelle anzeigen
+$url2 = YFormAdminer::dbTable(
+    rex::getTable('config'),
+    [
+        [
+            'col' => 'namespace',
+            'op' => '=',
+            'val' => 'core',
+        ],
+    ],
+);
+
+// SQL-Query im Fenster "SQL-Kommando" zur Ausführung bereitstellen
+$url3 = YFormAdminer::dbSql('SELECT namespace, key FROM rex_config');
+
+// Seite editieren für Tabelle X mit Datensatz mit id=... 
+$url4 = YFormAdminer::dbEdit(
+    rex::getTable('clang'),
+    1,
+);
+
+?>
+<ul>
+<li><a href="<?= $url1 ?>" target="_blank">Tabelle "rex_config"</a></li>
+<li><a href="<?= $url2 ?>" target="_blank">Tabelle "rex_config" gefiltert (where)</a></li>
+<li><a href="<?= $url3 ?>" target="_blank">SQL-Kommando</a></li>
+<li><a href="<?= $url4 ?>" target="_blank">Datensatz editieren (rex_clang Satz 1)</a></li>
+</ul>
+
+```
+
 ## Fehler, Ideen, Fragen, Support 
 
 Schreibt doch bitte auftretende Fehler, Anmerkungen und Wünsche als Issue auf [Github](https://github.com/FriendsOfREDAXO/yform_adminer/issues).

--- a/package.yml
+++ b/package.yml
@@ -1,11 +1,13 @@
 package: yform_adminer
-version: '1.4.0'
+version: '1.4.1'
 author: 'FriendsOfRedaxo | Christoph Böcker'
 supportpage: https://github.com/FriendsOfREDAXO/yform_adminer
 
 requires:
     redaxo: '^5.15.0'
-    yform: '^4.0.0'
+        packages:
+        yform: '^4.0.0'
+        yform/manager: '^4.0.0'
     adminer: '^1'
     php:
         version: '^8.1'

--- a/package.yml
+++ b/package.yml
@@ -5,9 +5,9 @@ supportpage: https://github.com/FriendsOfREDAXO/yform_adminer
 
 requires:
     redaxo: '^5.15.0'
-        packages:
+    packages:
         yform: '^4.0.0'
         yform/manager: '^4.0.0'
-    adminer: '^1'
+        dminer: '^1'
     php:
         version: '^8.1'


### PR DESCRIPTION
1) _package.yml_: Requires-Abschnitt war falsch strukturiert
2) _README.md_: Fehlende Hinweise zur Nutzung von Funktionen, die URLs in den Adminer hinein erzeugen, nachgetragen  