### PR TITLE
Kompatibilität zu YForm 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **25.06.2025 1.7.0**
+
+- Anpassung an YForm 5.0, da die Plugins ab Version 5 aufgelöst sind. 
+
 ## **17.03.2025 1.6.0**
 
 - St. Patricks-Day-Release: Anpassung der Versionsvoraussetzung an Adminer 3.0 in der __package.yml__

--- a/lib/YFormAdminer.php
+++ b/lib/YFormAdminer.php
@@ -196,13 +196,18 @@ class YFormAdminer
          * Note:
          * Stand 07.03.2023 gibt es nur das GH-Repo und keine neue Versionsnummer.
          * Daher auf das neue Fragment als Unterscheidungsmerkmal setzen.
+         * 
+         * Ab YForm 5.0 sind die Plugins aufgelöst, die Suche muss im Addon passieren
          */
-        $isPostYform404 = is_file(rex_path::plugin('yform', 'manager', 'fragments/yform/manager/page/list.php'));
+        $isNotPreYform405 = 
+            is_file(rex_path::addon('yform', 'fragments/yform/manager/page/list.php'))
+            ||
+            is_file(rex_path::plugin('yform', 'manager', 'fragments/yform/manager/page/list.php'));
 
         // Adminer-Button für den Datensatz
         $url = self::dbEdit($table->getTableName(), '___id___');
         $title = rex_i18n::msg('yform_adminer_ydl_ds_title');
-        if ($isPostYform404) {
+        if ($isNotPreYform405) {
             $buttons['adminer'] = [
                 'url' => $url,
                 'content' => self::icon(self::ICO_DB) . ' Adminer',
@@ -227,7 +232,7 @@ class YFormAdminer
             $url = self::dbSql($stmt);
 
             $title = rex_i18n::msg('yform_adminer_ydll_sql_title');
-            if ($isPostYform404) {
+            if ($isNotPreYform405) {
                 $buttons['adminer-sql'] = [
                     'url' => $url,
                     'content' => self::icon(self::ICO_QRY) . ' ' . rex_i18n::msg('yform_adminer_ydl_sql_label'),

--- a/package.yml
+++ b/package.yml
@@ -1,13 +1,11 @@
-package: yform_adminer
-version: '1.6.0'
+version: '1.7.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/yform_adminer
 
 requires:
     redaxo: '^5.15.0'
     packages:
-        yform: '^4.0.0'
-        yform/manager: '^4.0.0'
+        yform: '>=4.0.0'
         adminer: '>=1.0, <4'
     php:
         version: '^8.1'


### PR DESCRIPTION
Da in YForm 5 die Plugins aufgelöst sind, müssen Referenzen auf Dateien, die im Manager-Plugin liegen, geändert werden.

Diese Übergangs-Version sucht am alten und am neuen Ort, ist also mit YForm 4 und YForm 5 kompatibel.